### PR TITLE
Fix shift matrix calculation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ChIPQC
 Type: Package
 Title: Quality metrics for ChIPseq data
-Version: 1.22.1
+Version: 1.22.2
 Author: Tom Carroll, Wei Liu, Ines de Santiago, Rory Stark
 Maintainer: Tom Carroll <tc.infomatics@gmail.com>, Rory Stark <rory.stark@cruk.cam.ac.uk>
 Description: Quality metrics for ChIPseq data.

--- a/R/sampleQC.R
+++ b/R/sampleQC.R
@@ -264,7 +264,7 @@ sampleQC <- function(bamFile,bedFile=NULL,blklist=NULL,ChrOfInterest=NULL,GeneAn
     CovHistAll <- as.numeric(NA)     
   }
   if(!is.null(ShiftMat)){
-    ShiftsAv <- apply(ShiftMat,1,function(x)weighted.mean(x,Weights[colnames(ShiftMat)],na.rm=TRUE))
+    ShiftsAv <- apply(ShiftMat,1,function(x)weighted.mean(as.numeric(x),as.numeric(Weights[colnames(ShiftMat)]),na.rm=TRUE))
 
   }else{
     ShiftsAv <- as.numeric(NA)


### PR DESCRIPTION
This fixes NAs produced when calculating ShiftsAv, which resulted in an empty CCplot.
@romunov please check if everything is ok.