### PR TITLE
Improve read length estimation in sampleQC

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ChIPQC
 Type: Package
 Title: Quality metrics for ChIPseq data
-Version: 1.22.2
+Version: 1.22.3
 Author: Tom Carroll, Wei Liu, Ines de Santiago, Rory Stark
 Maintainer: Tom Carroll <tc.infomatics@gmail.com>, Rory Stark <rory.stark@cruk.cam.ac.uk>
 Description: Quality metrics for ChIPseq data.

--- a/R/sampleQC.R
+++ b/R/sampleQC.R
@@ -15,7 +15,7 @@ table_RleList <- function(x)
 sampleQC <- function(bamFile,bedFile=NULL,blklist=NULL,ChrOfInterest=NULL,GeneAnnotation=NULL,Window=400,FragmentLength=50,
                      shiftWindowStart=1,shiftWindowEnd=2,mapQCutoff=15,runCrossCor=FALSE,verboseT=TRUE){
 
-  ChrLengths <- scanBamHeader(bamFile)[[1]]$targets
+  ChrLengths <- sort(scanBamHeader(bamFile)[[1]]$targets, decreasing=TRUE)
 
   if(length(ChrLengths[ChrLengths < shiftWindowEnd - shiftWindowStart]) > 0){
     message("Removing ",length(ChrLengths[ChrLengths < shiftWindowEnd - shiftWindowStart]),
@@ -101,7 +101,7 @@ sampleQC <- function(bamFile,bedFile=NULL,blklist=NULL,ChrOfInterest=NULL,GeneAn
       ShiftMat <- cbind(ShiftMat,ShiftMattemp)
     }else{
       if(k == 1){
-        tocheckforreads <- 1000
+        tocheckforreads <- if (length(temp) < 1000) length(temp) else 1000
         readlength=round(mean(width(temp[1:tocheckforreads])))
       }
       


### PR DESCRIPTION
There is a problem with estimating read length when the first chromosome has a small number of mapped reads (<1000). In multiple occurrences the mitochondrial chromosome was problematic and prevented running the analysis. This is fixed in two ways, first we sort the chromosomes based on their names moving the chromosome 1 to the first place. It is less likely that there would not be enough reads to estimate length. If however, this happens we set the number of reads to check to the number of reads on that chromosome.