### PR TITLE
Fix enrichment heatmap plot to make axis labels readable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ChIPQC
 Type: Package
 Title: Quality metrics for ChIPseq data
-Version: 1.22.3
+Version: 1.22.4
 Author: Tom Carroll, Wei Liu, Ines de Santiago, Rory Stark
 Maintainer: Tom Carroll <tc.infomatics@gmail.com>, Rory Stark <rory.stark@cruk.cam.ac.uk>
 Description: Quality metrics for ChIPseq data.

--- a/R/plots.r
+++ b/R/plots.r
@@ -695,9 +695,14 @@ setMethod("plotRap", "list", function(object,facet=TRUE,
 
 makeRegiPlot <- function(regiScoresFrame){
   regiScoresFrame[,"GenomicIntervals"] <- factor(regiScoresFrame[,"GenomicIntervals"],levels=unique(as.vector(regiScoresFrame[,"GenomicIntervals"])))
-  Plot <- ggplot(regiScoresFrame, aes(Sample,GenomicIntervals))  
-  Plot <- Plot+geom_tile(aes(y=Sample,x=GenomicIntervals,fill = log2_Enrichment)) +
-    scale_fill_gradient2(low="blue",high="yellow",mid="black",midpoint=median(regiScoresFrame$log2_Enrichment))
+  Plot <- ggplot(regiScoresFrame, aes(x = GenomicIntervals, y = Sample))
+  Plot <- Plot +
+    geom_tile(aes(fill = log2_Enrichment)) +
+    scale_fill_gradient2(low="blue",high="yellow",mid="black",midpoint=median(regiScoresFrame$log2_Enrichment)) +
+    scale_x_discrete(guide = guide_axis(angle = 90)) +
+    theme(legend.position="top") +
+    ylab("")
+  
   return(Plot)
 }
 


### PR DESCRIPTION
X-axis labels of enrichment heatmap are barely readable:
![see](https://user-images.githubusercontent.com/10329834/90407292-a2475c00-e0a6-11ea-9134-73229f1b5643.png)

This PR rotates labels, positions the legend on the bottom and removes y-label to fit everything. Final result looks like this:
![image](https://user-images.githubusercontent.com/10329834/90405624-4da2e180-e0a4-11ea-83f7-fe5181618344.png)

I have also experimented with horizontal chart, but it breaks the compatibility for multiple samples.
